### PR TITLE
Refactor: Enhance Note class with file operations and add tests

### DIFF
--- a/lua/notes.lua
+++ b/lua/notes.lua
@@ -438,19 +438,46 @@ function M.notes_rename(new_name)
   -- Find all references before renaming
   local references = M.find_references(current_name)
 
-  -- Read current file content
-  local content = vim.fn.readfile(current_file)
+  local old_note = Note:new(current_name)
+  local new_note = Note:new(new_name)
 
-  -- Update header if it matches the current filename
-  if #content > 0 and content[1] == '# ' .. current_name then
-    content[1] = '# ' .. new_name
+  local was_old_note_existent = old_note:exists() -- Check existence before any operations
+  local content_to_write
+
+  if was_old_note_existent then
+    content_to_write = old_note:get_content()
+    local old_header_text = old_note:get_header() -- Gets text part, e.g., "old_name"
+
+    if old_header_text and old_header_text == current_name then
+      -- Header existed and matched old name: update it for the new note.
+      if #content_to_write > 0 then
+        content_to_write[1] = '# ' .. new_name
+      else
+        -- This implies get_header found a header but content_to_write is empty.
+        -- Should be rare. Defensively set content to just the new header.
+        content_to_write = {'# ' .. new_name}
+      end
+    elseif #content_to_write > 0 and (not old_header_text or not content_to_write[1]:match('^# ')) then
+      -- Content exists, but no header or first line isn't a standard header.
+      -- Prepend a new header for the new note.
+      table.insert(content_to_write, 1, '# ' .. new_name)
+    elseif #content_to_write == 0 then
+      -- Old note existed but was empty. New note gets a header.
+      content_to_write = {'# ' .. new_name}
+    end
+    -- Case: old_header_text exists but old_header_text ~= current_name.
+    -- The content (including its existing, different header) is carried over as is.
+  else
+    -- Old note doesn't exist. New note starts with its own header.
+    content_to_write = {'# ' .. new_name}
   end
 
-  -- Write content to new file
-  vim.fn.writefile(content, new_file_path)
+  new_note:write_content(content_to_write)
 
-  -- Delete old file
-  vim.fn.delete(current_file)
+  -- Delete old file only if it actually existed when we started.
+  if was_old_note_existent then
+    vim.fn.delete(old_note:path())
+  end
 
   -- Update all references
   for _, ref in ipairs(references) do

--- a/lua/notes.lua
+++ b/lua/notes.lua
@@ -455,7 +455,7 @@ function M.notes_rename(new_name)
       else
         -- This implies get_header found a header but content_to_write is empty.
         -- Should be rare. Defensively set content to just the new header.
-        content_to_write = {'# ' .. new_name}
+        content_to_write = { '# ' .. new_name }
       end
     elseif #content_to_write > 0 and (not old_header_text or not content_to_write[1]:match('^# ')) then
       -- Content exists, but no header or first line isn't a standard header.
@@ -463,13 +463,13 @@ function M.notes_rename(new_name)
       table.insert(content_to_write, 1, '# ' .. new_name)
     elseif #content_to_write == 0 then
       -- Old note existed but was empty. New note gets a header.
-      content_to_write = {'# ' .. new_name}
+      content_to_write = { '# ' .. new_name }
     end
     -- Case: old_header_text exists but old_header_text ~= current_name.
     -- The content (including its existing, different header) is carried over as is.
   else
     -- Old note doesn't exist. New note starts with its own header.
-    content_to_write = {'# ' .. new_name}
+    content_to_write = { '# ' .. new_name }
   end
 
   new_note:write_content(content_to_write)

--- a/lua/notes.lua
+++ b/lua/notes.lua
@@ -438,24 +438,33 @@ function M.notes_rename(new_name)
   -- Find all references before renaming
   local references = M.find_references(current_name)
 
-  local old_note = Note:new(current_name)
-  local new_note = Note:new(new_name)
+  local old_note = Note:new(current_name) -- Exists on disk due to prior checks
+  local new_note = Note:new(new_name) -- Does not exist on disk due to prior checks
 
-  -- Get content from the old note. The function's initial checks ensure old_note file exists.
-  local content_for_new_note = old_note:get_content()
+  -- Get content from old_note (this will lazy-load into old_note._content)
+  local old_content_table = old_note:get_content()
 
-  -- If the old note's content started with a header matching its name, update that header.
-  -- Otherwise, the content (with its existing different header, or no header) is used as-is for the new note.
-  if #content_for_new_note > 0 and content_for_new_note[1] == '# ' .. current_name then
-    content_for_new_note[1] = '# ' .. new_name
+  -- Set this content for the new_note (copies it into new_note._content, marks new_note as dirty)
+  new_note:set_content(old_content_table)
+
+  -- Conditionally modify the header in new_note's in-memory content.
+  -- We operate on new_note's content. If the first line (which came from old_note)
+  -- was a header matching current_name, we want to change it to new_name.
+  -- The get_content() here ensures we have the reference to new_note's internal table,
+  -- though set_header will call it again if it wasn't already populated.
+  local new_note_memory_content = new_note:get_content()
+  if #new_note_memory_content > 0 and new_note_memory_content[1] == '# ' .. current_name then
+    -- Modify the header of new_note's in-memory content to reflect the new name.
+    -- set_header will operate on new_note._content and ensure _is_dirty is true.
+    new_note:set_header(new_name)
   end
+  -- If the header didn't match (custom header) or no header, new_note's content is already correct.
 
-  -- Write the (potentially modified) content to the new note.
-  new_note:write_content(content_for_new_note)
+  -- Write the new_note's content (which is now prepared) to disk.
+  new_note:write()
 
-  -- Delete the old file. vim.fn.delete is generally safe; it won't error if file is already gone,
-  -- but the function's prior checks mean it should be there.
-  vim.fn.delete(old_note:path())
+  -- Delete the old_note file from disk using the new Note method.
+  old_note:delete_from_disk()
 
   -- Update all references
   for _, ref in ipairs(references) do
@@ -519,16 +528,22 @@ function M.notes_remove()
     return
   end
 
-  -- Close the buffer
-  vim.cmd('bdelete!')
+  local note_to_remove = Note:new(current_name)
 
-  -- Remove the file if it exists
-  local file_exists = vim.fn.filereadable(current_file) == 1
-  if file_exists then
-    vim.fn.delete(current_file)
+  -- Attempt to delete the note file from disk
+  local deletion_successful = note_to_remove:delete_from_disk()
+
+  if deletion_successful then
+    -- Close the buffer only after successful deletion from disk (or if it never existed)
+    -- It's important to use 'bdelete!' to ensure the buffer is closed without saving,
+    -- especially if it was the file we just deleted.
+    vim.cmd('bdelete!')
+    print('Removed note "' .. current_name .. '"')
+  else
+    -- This case implies vim.fn.delete() failed, which is rare for existing files
+    -- unless there are permission issues.
+    print('Error: Could not delete note file for "' .. current_name .. '".')
   end
-
-  print('Removed note "' .. current_name .. '"')
 end
 
 -- Wrap the word under cursor in [[ ]] to make it a link

--- a/lua/notes/note.lua
+++ b/lua/notes/note.lua
@@ -1,5 +1,4 @@
 local Note = {}
-
 Note.__index = Note
 
 function Note:new(name)
@@ -10,8 +9,10 @@ function Note:new(name)
 
   local obj = {
     name = name,
+    _content = nil, -- Content table, nil until loaded or set
+    _is_dirty = false, -- True if _content has changes not written to disk
+    _exists_on_disk = nil, -- Cache for file existence (true, false, or nil if unchecked)
   }
-
   setmetatable(obj, Note)
   return obj
 end
@@ -21,57 +22,118 @@ function Note:path()
 end
 
 function Note:exists()
-  return vim.fn.filereadable(self:path()) == 1
+  if self._exists_on_disk == nil then
+    self._exists_on_disk = vim.fn.filereadable(self:path()) == 1
+  end
+  return self._exists_on_disk
 end
 
-function Note:create_with_header()
-  if not self:exists() then
-    local header_line = '# ' .. self.name
-    self:write_content({ header_line })
+function Note:_read_content_from_disk()
+  -- Assumes self:exists() has been called and confirmed file existence.
+  -- This is a helper, primarily for get_content's lazy load.
+  if self._exists_on_disk then -- Should be true if called after self:exists() is true
+    return vim.fn.readfile(self:path())
   end
+  return {} -- Should ideally not be hit if logic is correct
 end
 
 function Note:get_content()
-  if not self:exists() then
-    return {}
+  if self._content == nil then
+    if self:exists() then -- This call also populates/updates self._exists_on_disk
+      self._content = self:_read_content_from_disk()
+      self._is_dirty = false -- Content is now sync'd with disk
+    else
+      self._content = {} -- File doesn't exist, so in-memory content starts empty
+      -- _is_dirty remains false as it's pristine, not a user change yet
+    end
   end
-  return vim.fn.readfile(self:path())
+  -- Return the actual internal table. Callers must use methods to modify it
+  -- if they want _is_dirty to be managed correctly.
+  return self._content
+end
+
+function Note:set_content(lines_table)
+  -- Creates a copy for internal storage
+  self._content = {}
+  for _, line in ipairs(lines_table) do
+    table.insert(self._content, line)
+  end
+  self._is_dirty = true
+  -- Setting content in memory doesn't change _exists_on_disk status until write.
 end
 
 function Note:get_header()
-  local content = self:get_content()
-  if #content > 0 then
-    local first_line = content[1]
-    -- Check if the first line is a header (starts with '# ')
-    if first_line:match('^# ') then
-      -- Return the header text without the '# '
+  local current_content = self:get_content() -- Ensures _content is populated (lazy load)
+  if #current_content > 0 then
+    local first_line = current_content[1]
+    if first_line and type(first_line) == 'string' and first_line:match('^# ') then
       return first_line:sub(3)
     end
   end
   return nil
 end
 
-function Note:write_content(lines_table)
-  vim.fn.writefile(lines_table, self:path())
-end
-
 function Note:set_header(name_for_header)
   local header_name = name_for_header or self.name
-  local content = self:get_content()
+  -- Ensure content is loaded or initialized before modification
+  self:get_content() -- Ensures self._content is populated; result not directly needed here
   local new_header_line = '# ' .. header_name
 
-  if #content == 1 and content[1] == '' then
-    -- File contains a single empty line, overwrite it with the header.
-    content = { new_header_line }
-  elseif #content > 0 and content[1]:match('^# ') then
-    -- Content exists and first line is already a header, update it.
-    content[1] = new_header_line
+  if #self._content == 1 and self._content[1] == '' then
+    self._content = { new_header_line } -- Replace single empty line
+  elseif #self._content > 0 and self._content[1]:match('^# ') then
+    self._content[1] = new_header_line -- Update existing header
   else
-    -- Content is either truly empty ({}), or has content that doesn't start with a header.
-    -- Prepend the new header.
-    table.insert(content, 1, new_header_line)
+    table.insert(self._content, 1, new_header_line) -- Prepend new header
   end
-  self:write_content(content)
+  self._is_dirty = true
+end
+
+function Note:write()
+  local needs_write = self._is_dirty
+  if not needs_write and self._content ~= nil and not self:exists() then
+    -- Content has been set (e.g. by set_header on a new note), but file isn't on disk
+    needs_write = true
+  end
+
+  if needs_write then
+    if self._content == nil then
+      -- This case should ideally be avoided if dirty is true or content is set for a new file.
+      -- Defaulting to empty content if somehow reached.
+      self._content = {}
+    end
+    vim.fn.writefile(self._content, self:path())
+    self._is_dirty = false
+    self._exists_on_disk = true -- It now exists on disk
+    return true -- Write occurred
+  end
+  return false -- No write occurred
+end
+
+function Note:create_with_header()
+  -- Creates the note file with a header ONLY if it doesn't already exist on disk.
+  if not self:exists() then
+    self:set_header(self.name) -- Modifies in-memory _content, sets _is_dirty = true
+    self:write() -- Writes _content to disk
+  end
+end
+
+function Note:delete_from_disk()
+  if self:exists() then
+    local success = vim.fn.delete(self:path()) == 0 -- vim.fn.delete returns 0 on success
+    if success then
+      self._exists_on_disk = false
+      self._content = nil -- Or {} if preferred for consistency, but nil signifies no loaded content
+      self._is_dirty = false
+      return true
+    end
+    return false -- Deletion failed
+  end
+  -- If file doesn't exist on disk, consider it a successful "deletion" in terms of state
+  self._exists_on_disk = false
+  self._content = nil
+  self._is_dirty = false
+  return true
 end
 
 return Note

--- a/lua/notes/note.lua
+++ b/lua/notes/note.lua
@@ -26,9 +26,48 @@ end
 
 function Note:create_with_header()
   if not self:exists() then
-    local header = '# ' .. self.name
-    vim.fn.writefile({ header }, self:path())
+    local header_line = '# ' .. self.name
+    self:write_content({ header_line })
   end
+end
+
+function Note:get_content()
+  if not self:exists() then
+    return {}
+  end
+  return vim.fn.readfile(self:path())
+end
+
+function Note:get_header()
+  local content = self:get_content()
+  if #content > 0 then
+    local first_line = content[1]
+    -- Check if the first line is a header (starts with '# ')
+    if first_line:match('^# ') then
+      -- Return the header text without the '# '
+      return first_line:sub(3)
+    end
+  end
+  return nil
+end
+
+function Note:write_content(lines_table)
+  vim.fn.writefile(lines_table, self:path())
+end
+
+function Note:set_header(name_for_header)
+  local header_name = name_for_header or self.name
+  local content = self:get_content()
+  local new_header_line = '# ' .. header_name
+
+  if #content > 0 and content[1]:match('^# ') then
+    -- Update existing header
+    content[1] = new_header_line
+  else
+    -- Prepend new header
+    table.insert(content, 1, new_header_line)
+  end
+  self:write_content(content)
 end
 
 return Note

--- a/lua/notes/note.lua
+++ b/lua/notes/note.lua
@@ -60,11 +60,15 @@ function Note:set_header(name_for_header)
   local content = self:get_content()
   local new_header_line = '# ' .. header_name
 
-  if #content > 0 and content[1]:match('^# ') then
-    -- Update existing header
+  if #content == 1 and content[1] == '' then
+    -- File contains a single empty line, overwrite it with the header.
+    content = { new_header_line }
+  elseif #content > 0 and content[1]:match('^# ') then
+    -- Content exists and first line is already a header, update it.
     content[1] = new_header_line
   else
-    -- Prepend new header
+    -- Content is either truly empty ({}), or has content that doesn't start with a header.
+    -- Prepend the new header.
     table.insert(content, 1, new_header_line)
   end
   self:write_content(content)

--- a/tests/note_spec.lua
+++ b/tests/note_spec.lua
@@ -1,206 +1,286 @@
 local helpers = require('tests.support.helpers')
-local Note = require('notes.note') -- Assuming 'notes.note' is the correct path from rtp
+local Note = require('notes.note')
 
-describe('Note Class', function()
+describe('Stateful Note Class', function()
+  local note_name
+  local note
+  local note_path
+
   before_each(function()
-    helpers.setup_test_env() -- Sets up temp directory and loads plugin
+    helpers.setup_test_env()
+    note_name = 'TestNote'
+    note = Note:new(note_name)
+    note_path = note:path() -- Store path for direct checks
   end)
 
   after_each(function()
-    helpers.teardown_test_env() -- Cleans up temp directory
+    helpers.teardown_test_env()
   end)
 
-  describe('Note:new() and Note:path()', function()
-    it('should create a new note object with a name and correct path', function()
-      local note_name = 'MyTestNote'
-      local note = Note:new(note_name)
+  describe('Note:new()', function()
+    it('initializes with correct name and path', function()
       assert.are.equal(note_name, note.name)
       assert.are.equal(note_name .. '.md', note:path())
+    end)
+
+    it('initializes with nil content, not dirty, and unchecked disk existence', function()
+      assert.is_nil(note._content)
+      assert.is_false(note._is_dirty)
+      assert.is_nil(note._exists_on_disk)
     end)
   end)
 
   describe('Note:exists()', function()
-    it('should return false if the note file does not exist', function()
-      local note = Note:new('NonExistentNote')
+    it('returns false and caches if file does not exist', function()
       assert.is_false(note:exists())
+      assert.is_false(note._exists_on_disk)
     end)
 
-    it('should return true if the note file exists', function()
-      local note_name = 'ExistingNote'
-      helpers.create_test_file(note_name .. '.md', '# ' .. note_name)
-      local note = Note:new(note_name)
+    it('returns true and caches if file exists', function()
+      helpers.create_test_file(note_path, '# Existing')
       assert.is_true(note:exists())
+      assert.is_true(note._exists_on_disk)
+    end)
+
+    it('uses cached disk existence value on subsequent calls', function()
+      assert.is_false(note:exists()) -- First call, sets _exists_on_disk to false
+      -- Create file externally *after* first check, cache should still say false
+      helpers.create_test_file(note_path, '# Created After Check')
+      assert.is_false(note:exists()) -- Should use cached false
     end)
   end)
 
-  describe('Note:get_content()', function()
-    it('should return an empty table if the note file does not exist', function()
-      local note = Note:new('NoContentNote')
+  describe('Note:get_content() - Lazy Loading', function()
+    it('loads content from disk if file exists and content is nil', function()
+      local file_lines = { '# Title', 'Line 1' }
+      helpers.create_test_file(note_path, table.concat(file_lines, '\n'))
+      -- Pre-conditions
+      assert.is_nil(note._content)
+      assert.is_true(note:exists()) -- This will cache _exists_on_disk = true
+
       local content = note:get_content()
-      assert.is_table(content)
-      assert.are.equal(0, #content)
+      assert.are.same(file_lines, content)
+      assert.are.same(file_lines, note._content) -- Internal content set
+      assert.is_false(note._is_dirty) -- Loaded from disk, so not dirty
     end)
 
-    it('should return file content as a table of strings', function()
-      local note_name = 'ContentNote'
-      local file_content = { '# ' .. note_name, 'Line 1', 'Line 2' }
-      helpers.create_test_file(note_name .. '.md', table.concat(file_content, '\n'))
-      local note = Note:new(note_name)
+    it('returns empty table if file does not exist and content is nil', function()
+      assert.is_false(note:exists()) -- Caches _exists_on_disk = false
+      assert.is_nil(note._content)
+
       local content = note:get_content()
-      assert.are.same(file_content, content)
+      assert.are.same({}, content)
+      assert.are.same({}, note._content) -- Internal content set to empty
+      assert.is_false(note._is_dirty)
+    end)
+
+    it('returns existing _content if already populated', function()
+      note._content = { '# Manual Set' }
+      note._is_dirty = true -- Simulate prior modification
+
+      local content = note:get_content()
+      assert.are.same({ '# Manual Set' }, content)
+      assert.is_true(note._is_dirty) -- State should not change
     end)
   end)
 
-  describe('Note:write_content()', function()
-    it('should write content to a new file', function()
-      local note_name = 'WriteTestNote'
-      local note = Note:new(note_name)
-      local lines_to_write = { '# ' .. note_name, 'Hello from test!' }
-      note:write_content(lines_to_write)
+  describe('Note:set_content()', function()
+    it('sets internal _content and marks note as dirty', function()
+      local new_lines = { '# New Content', 'Line A' }
+      note:set_content(new_lines)
 
-      assert.is_true(note:exists())
-      local written_content = vim.fn.readfile(note:path())
-      assert.are.same(lines_to_write, written_content)
+      assert.are.same(new_lines, note._content)
+      assert.is_true(note._is_dirty)
     end)
 
-    it('should overwrite content of an existing file', function()
-      local note_name = 'OverwriteTestNote'
-      helpers.create_test_file(note_name .. '.md', 'Initial content')
-
-      local note = Note:new(note_name)
-      local new_lines = { '# Overwritten', 'New content here' }
-      note:write_content(new_lines)
-
-      local written_content = vim.fn.readfile(note:path())
-      assert.are.same(new_lines, written_content)
+    it('creates a copy of the input table', function()
+      local original_lines = { 'Original Line' }
+      note:set_content(original_lines)
+      original_lines[1] = 'Modified Original Line' -- Modify original after set
+      assert.are.same({ 'Original Line' }, note._content) -- Internal should be unaffected
     end)
   end)
 
   describe('Note:get_header()', function()
-    it('should return header text if file has a matching header', function()
-      local note_name = 'HeaderNote'
-      helpers.create_test_file(note_name .. '.md', '# ' .. note_name .. '\nSome content')
-      local note = Note:new(note_name)
-      assert.are.equal(note_name, note:get_header())
+    it('returns header from lazy-loaded content', function()
+      helpers.create_test_file(note_path, '# My Header\nData')
+      assert.are.equal('My Header', note:get_header())
     end)
 
-    it('should return custom header text if file has a different header', function()
-      local note_name = 'CustomHeaderNoteFile'
-      local custom_header = 'My Custom Header'
-      helpers.create_test_file(note_name .. '.md', '# ' .. custom_header .. '\nSome content')
-      local note = Note:new(note_name) -- Note object name vs actual header
-      assert.are.equal(custom_header, note:get_header())
+    it('returns header from in-memory (set) content', function()
+      note:set_content({ '# InMemory Header', 'stuff' })
+      assert.are.equal('InMemory Header', note:get_header())
     end)
 
-    it('should return nil if file has no header line', function()
-      local note_name = 'NoHeaderNote'
-      helpers.create_test_file(note_name .. '.md', 'Just regular text\nMore text')
-      local note = Note:new(note_name)
+    it('returns nil if no header (lazy-loaded)', function()
+      helpers.create_test_file(note_path, 'No header here')
       assert.is_nil(note:get_header())
     end)
 
-    it('should return nil if file is empty', function()
-      local note_name = 'EmptyNoteForHeaderTest'
-      helpers.create_test_file(note_name .. '.md', '')
-      local note = Note:new(note_name)
+    it('returns nil if no header (in-memory)', function()
+      note:set_content({ 'No header here either' })
       assert.is_nil(note:get_header())
     end)
 
-    it('should return nil if file does not exist', function()
-      local note = Note:new('NonExistentForHeader')
-      assert.is_nil(note:get_header())
-    end)
-
-    it('should return nil if first line is not a valid header format (e.g. no space)', function()
-      local note_name = 'MalformedHeaderNote'
-      helpers.create_test_file(note_name .. '.md', '#' .. note_name .. '\nSome content')
-      local note = Note:new(note_name)
+    it('returns nil for empty content (lazy-loaded or in-memory)', function()
+      assert.is_nil(note:get_header()) -- Not on disk, _content becomes {}
+      note:set_content({}) -- Explicitly set empty
       assert.is_nil(note:get_header())
     end)
   end)
 
   describe('Note:set_header()', function()
-    it('should create a header in a new file', function()
-      local note_name = 'SetHeaderNewFile'
-      local note = Note:new(note_name)
-      note:set_header() -- Uses note.name by default
-      local content = note:get_content()
-      assert.are.equal(1, #content)
-      assert.are.equal('# ' .. note_name, content[1])
+    it('sets header for new (empty) content', function()
+      note:set_header('New Note Title') -- get_content called internally, _content becomes {} then header added
+      assert.are.same({ '# New Note Title' }, note._content)
+      assert.is_true(note._is_dirty)
     end)
 
-    it('should create a header with specified name in a new file', function()
-      local note_name = 'SetHeaderNewFileCustom'
-      local header_text = 'My Custom Header for New File'
-      local note = Note:new(note_name)
-      note:set_header(header_text)
-      local content = note:get_content()
-      assert.are.equal(1, #content)
-      assert.are.equal('# ' .. header_text, content[1])
+    it('updates existing header', function()
+      note:set_content({ '# Old Title', 'Line 1' })
+      note:set_header('Updated Title')
+      assert.are.same({ '# Updated Title', 'Line 1' }, note._content)
+      assert.is_true(note._is_dirty)
     end)
 
-    it('should update an existing header', function()
-      local note_name = 'UpdateHeaderNote'
-      local new_header_text = 'Updated Shiny Header'
-      helpers.create_test_file(note_name .. '.md', '# Old Header\nLine 2')
-      local note = Note:new(note_name)
-      note:set_header(new_header_text)
-
-      local content = note:get_content()
-      assert.are.equal(2, #content)
-      assert.are.equal('# ' .. new_header_text, content[1])
-      assert.are.equal('Line 2', content[2])
+    it('prepends header if no header exists and content is present', function()
+      note:set_content({ 'First line of text' })
+      note:set_header('Prepended Title')
+      assert.are.same({ '# Prepended Title', 'First line of text' }, note._content)
+      assert.is_true(note._is_dirty)
     end)
 
-    it('should add a header to a file that has content but no header', function()
-      local note_name = 'AddHeaderToExistingContent'
-      local file_content = { 'First line of text', 'Second line' }
-      helpers.create_test_file(note_name .. '.md', table.concat(file_content, '\n'))
-      local note = Note:new(note_name)
-      note:set_header() -- Uses note.name
-
-      local content = note:get_content()
-      assert.are.equal(3, #content)
-      assert.are.equal('# ' .. note_name, content[1])
-      assert.are.equal(file_content[1], content[2])
-      assert.are.equal(file_content[2], content[3])
+    it('replaces a single empty line with the header', function()
+      note:set_content({ '' })
+      note:set_header('Title For Empty Line File')
+      assert.are.same({ '# Title For Empty Line File' }, note._content)
+      assert.is_true(note._is_dirty)
     end)
 
-    it('should add a header to an empty file', function()
-      local note_name = 'AddHeaderToEmptyFile'
-      helpers.create_test_file(note_name .. '.md', '')
-      local note = Note:new(note_name)
-      note:set_header()
+    it('uses note.name if no header name is provided', function()
+      note:set_header() -- note_name is 'TestNote'
+      assert.are.same({ '# TestNote' }, note._content)
+      assert.is_true(note._is_dirty)
+    end)
+  end)
 
-      local content = note:get_content()
-      assert.are.equal(1, #content)
-      assert.are.equal('# ' .. note_name, content[1])
+  describe('Note:write()', function()
+    it('writes dirty content to a new file', function()
+      note:set_content({ '# New File Content' }) -- is_dirty = true, _content is set
+      assert.is_false(note:exists()) -- Not on disk yet
+
+      local write_occurred = note:write()
+      assert.is_true(write_occurred)
+      assert.is_true(note:exists()) -- Now exists on disk
+      assert.is_false(note._is_dirty) -- No longer dirty
+      assert.are.same({ '# New File Content' }, vim.fn.readfile(note_path))
+    end)
+
+    it('writes dirty content to an existing file (overwrite)', function()
+      helpers.create_test_file(note_path, '# Old Content')
+      note:get_content() -- Load old content, not dirty
+      note:set_content({ '# Updated Content' }) -- Modify, becomes dirty
+
+      local write_occurred = note:write()
+      assert.is_true(write_occurred)
+      assert.is_true(note:exists())
+      assert.is_false(note._is_dirty)
+      assert.are.same({ '# Updated Content' }, vim.fn.readfile(note_path))
+    end)
+
+    it('does not write if not dirty and file exists', function()
+      helpers.create_test_file(note_path, '# Clean Content')
+      note:get_content() -- Load, _is_dirty = false, _exists_on_disk = true
+
+      local write_occurred = note:write()
+      assert.is_false(write_occurred)
+      assert.is_false(note._is_dirty) -- Remains not dirty
+      -- Verify content on disk is unchanged (though this test doesn't change it)
+      assert.are.same({ '# Clean Content' }, vim.fn.readfile(note_path))
+    end)
+
+    it('writes if content is set (not nil) even if not "dirty", but file does not exist', function()
+      note._content = { '# Programmatically Set, Not Dirty Yet' } -- Simulate direct _content set without dirty flag
+      assert.is_false(note._is_dirty)
+      assert.is_false(note:exists())
+
+      local write_occurred = note:write()
+      assert.is_true(write_occurred)
+      assert.is_true(note:exists())
+      assert.is_false(note._is_dirty) -- Write resets dirty
+      assert.are.same({ '# Programmatically Set, Not Dirty Yet' }, vim.fn.readfile(note_path))
+    end)
+
+    it('writes empty content if _content is empty and dirty', function()
+      note:set_content({}) -- dirty = true, _content = {}
+      local write_occurred = note:write()
+      assert.is_true(write_occurred)
+      assert.is_true(note:exists())
+      assert.is_false(note._is_dirty)
+      local written_content = vim.fn.readfile(note_path)
+      -- readfile on an empty file might return {''} or {} depending on exact vim version/OS.
+      -- Test if it's one of these.
+      local is_empty_table = #written_content == 0
+      local is_table_with_one_empty_string = #written_content == 1 and written_content[1] == ''
+      assert.is_true(is_empty_table or is_table_with_one_empty_string, 'File content should be effectively empty')
     end)
   end)
 
   describe('Note:create_with_header()', function()
-    it('should create a new file with a header if it does not exist', function()
-      local note_name = 'CreateWithHeaderTest'
-      local note = Note:new(note_name)
+    it('creates a new file with header if it does not exist', function()
       assert.is_false(note:exists())
-
       note:create_with_header()
 
       assert.is_true(note:exists())
-      local content = note:get_content()
-      assert.are.equal(1, #content)
-      assert.are.equal('# ' .. note_name, content[1])
+      assert.are.same({ '# ' .. note_name }, vim.fn.readfile(note_path))
+      assert.are.same({ '# ' .. note_name }, note._content) -- Internal content should be set
+      assert.is_false(note._is_dirty) -- Written, so not dirty
+      assert.is_true(note._exists_on_disk) -- Written, so exists
     end)
 
-    it('should do nothing if the file already exists', function()
-      local note_name = 'CreateWithHeaderExistsTest'
-      local initial_content = { '# ' .. note_name, 'Existing line' }
-      helpers.create_test_file(note_name .. '.md', table.concat(initial_content, '\n'))
-      local note = Note:new(note_name)
+    it('does nothing if file already exists', function()
+      local initial_lines = { '# Existing Header', 'Line 1' }
+      helpers.create_test_file(note_path, table.concat(initial_lines, '\n'))
+
+      -- Reset note state to simulate fresh object for existing file
+      note = Note:new(note_name)
+      assert.is_nil(note._content) -- Content not loaded yet
+
       note:create_with_header()
 
-      local content = note:get_content()
-      assert.are.same(initial_content, content, 'Content should not change if file exists')
+      -- File on disk should be unchanged
+      assert.are.same(initial_lines, vim.fn.readfile(note_path))
+      -- Internal state of note should also be unchanged (still nil content, not dirty)
+      assert.is_nil(note._content)
+      assert.is_false(note._is_dirty)
+      assert.is_true(note:exists()) -- exists() was called by create_with_header
+    end)
+  end)
+
+  describe('Note:delete_from_disk()', function()
+    it('deletes an existing file and updates state', function()
+      helpers.create_test_file(note_path, '# To Be Deleted')
+      note:get_content() -- Load it, exists=true, dirty=false
+
+      assert.is_true(note:exists())
+      local delete_success = note:delete_from_disk()
+
+      assert.is_true(delete_success)
+      assert.is_false(note:exists()) -- Now reports not existing
+      assert.is_false(note._exists_on_disk) -- Cache updated
+      assert.is_nil(note._content) -- Content cleared
+      assert.is_false(note._is_dirty) -- State reset
+      assert.are.equal(0, vim.fn.filereadable(note_path)) -- Check disk
+    end)
+
+    it('handles non-existent file gracefully and updates state', function()
+      assert.is_false(note:exists()) -- Ensure it's known not to exist
+
+      local delete_success = note:delete_from_disk()
+      assert.is_true(delete_success)
+      assert.is_false(note._exists_on_disk)
+      assert.is_nil(note._content)
+      assert.is_false(note._is_dirty)
     end)
   end)
 end)

--- a/tests/note_spec.lua
+++ b/tests/note_spec.lua
@@ -47,7 +47,7 @@ describe('Note Class', function()
       helpers.create_test_file(note_name .. '.md', table.concat(file_content, '\n'))
       local note = Note:new(note_name)
       local content = note:get_content()
-      assert.deep_equal(file_content, content)
+      assert.are.same(file_content, content)
     end)
   end)
 
@@ -60,7 +60,7 @@ describe('Note Class', function()
 
       assert.is_true(note:exists())
       local written_content = vim.fn.readfile(note:path())
-      assert.deep_equal(lines_to_write, written_content)
+      assert.are.same(lines_to_write, written_content)
     end)
 
     it('should overwrite content of an existing file', function()
@@ -72,7 +72,7 @@ describe('Note Class', function()
       note:write_content(new_lines)
 
       local written_content = vim.fn.readfile(note:path())
-      assert.deep_equal(new_lines, written_content)
+      assert.are.same(new_lines, written_content)
     end)
   end)
 
@@ -124,7 +124,6 @@ describe('Note Class', function()
       local note_name = 'SetHeaderNewFile'
       local note = Note:new(note_name)
       note:set_header() -- Uses note.name by default
-
       local content = note:get_content()
       assert.are.equal(1, #content)
       assert.are.equal('# ' .. note_name, content[1])
@@ -135,7 +134,6 @@ describe('Note Class', function()
       local header_text = 'My Custom Header for New File'
       local note = Note:new(note_name)
       note:set_header(header_text)
-
       local content = note:get_content()
       assert.are.equal(1, #content)
       assert.are.equal('# ' .. header_text, content[1])
@@ -198,12 +196,11 @@ describe('Note Class', function()
       local note_name = 'CreateWithHeaderExistsTest'
       local initial_content = { '# ' .. note_name, 'Existing line' }
       helpers.create_test_file(note_name .. '.md', table.concat(initial_content, '\n'))
-
       local note = Note:new(note_name)
       note:create_with_header()
 
       local content = note:get_content()
-      assert.deep_equal(initial_content, content, "Content should not change if file exists")
+      assert.are.same(initial_content, content, 'Content should not change if file exists')
     end)
   end)
 end)

--- a/tests/note_spec.lua
+++ b/tests/note_spec.lua
@@ -1,0 +1,209 @@
+local helpers = require('tests.support.helpers')
+local Note = require('notes.note') -- Assuming 'notes.note' is the correct path from rtp
+
+describe('Note Class', function()
+  before_each(function()
+    helpers.setup_test_env() -- Sets up temp directory and loads plugin
+  end)
+
+  after_each(function()
+    helpers.teardown_test_env() -- Cleans up temp directory
+  end)
+
+  describe('Note:new() and Note:path()', function()
+    it('should create a new note object with a name and correct path', function()
+      local note_name = 'MyTestNote'
+      local note = Note:new(note_name)
+      assert.are.equal(note_name, note.name)
+      assert.are.equal(note_name .. '.md', note:path())
+    end)
+  end)
+
+  describe('Note:exists()', function()
+    it('should return false if the note file does not exist', function()
+      local note = Note:new('NonExistentNote')
+      assert.is_false(note:exists())
+    end)
+
+    it('should return true if the note file exists', function()
+      local note_name = 'ExistingNote'
+      helpers.create_test_file(note_name .. '.md', '# ' .. note_name)
+      local note = Note:new(note_name)
+      assert.is_true(note:exists())
+    end)
+  end)
+
+  describe('Note:get_content()', function()
+    it('should return an empty table if the note file does not exist', function()
+      local note = Note:new('NoContentNote')
+      local content = note:get_content()
+      assert.is_table(content)
+      assert.are.equal(0, #content)
+    end)
+
+    it('should return file content as a table of strings', function()
+      local note_name = 'ContentNote'
+      local file_content = { '# ' .. note_name, 'Line 1', 'Line 2' }
+      helpers.create_test_file(note_name .. '.md', table.concat(file_content, '\n'))
+      local note = Note:new(note_name)
+      local content = note:get_content()
+      assert.deep_equal(file_content, content)
+    end)
+  end)
+
+  describe('Note:write_content()', function()
+    it('should write content to a new file', function()
+      local note_name = 'WriteTestNote'
+      local note = Note:new(note_name)
+      local lines_to_write = { '# ' .. note_name, 'Hello from test!' }
+      note:write_content(lines_to_write)
+
+      assert.is_true(note:exists())
+      local written_content = vim.fn.readfile(note:path())
+      assert.deep_equal(lines_to_write, written_content)
+    end)
+
+    it('should overwrite content of an existing file', function()
+      local note_name = 'OverwriteTestNote'
+      helpers.create_test_file(note_name .. '.md', 'Initial content')
+
+      local note = Note:new(note_name)
+      local new_lines = { '# Overwritten', 'New content here' }
+      note:write_content(new_lines)
+
+      local written_content = vim.fn.readfile(note:path())
+      assert.deep_equal(new_lines, written_content)
+    end)
+  end)
+
+  describe('Note:get_header()', function()
+    it('should return header text if file has a matching header', function()
+      local note_name = 'HeaderNote'
+      helpers.create_test_file(note_name .. '.md', '# ' .. note_name .. '\nSome content')
+      local note = Note:new(note_name)
+      assert.are.equal(note_name, note:get_header())
+    end)
+
+    it('should return custom header text if file has a different header', function()
+      local note_name = 'CustomHeaderNoteFile'
+      local custom_header = 'My Custom Header'
+      helpers.create_test_file(note_name .. '.md', '# ' .. custom_header .. '\nSome content')
+      local note = Note:new(note_name) -- Note object name vs actual header
+      assert.are.equal(custom_header, note:get_header())
+    end)
+
+    it('should return nil if file has no header line', function()
+      local note_name = 'NoHeaderNote'
+      helpers.create_test_file(note_name .. '.md', 'Just regular text\nMore text')
+      local note = Note:new(note_name)
+      assert.is_nil(note:get_header())
+    end)
+
+    it('should return nil if file is empty', function()
+      local note_name = 'EmptyNoteForHeaderTest'
+      helpers.create_test_file(note_name .. '.md', '')
+      local note = Note:new(note_name)
+      assert.is_nil(note:get_header())
+    end)
+
+    it('should return nil if file does not exist', function()
+      local note = Note:new('NonExistentForHeader')
+      assert.is_nil(note:get_header())
+    end)
+
+    it('should return nil if first line is not a valid header format (e.g. no space)', function()
+      local note_name = 'MalformedHeaderNote'
+      helpers.create_test_file(note_name .. '.md', '#' .. note_name .. '\nSome content')
+      local note = Note:new(note_name)
+      assert.is_nil(note:get_header())
+    end)
+  end)
+
+  describe('Note:set_header()', function()
+    it('should create a header in a new file', function()
+      local note_name = 'SetHeaderNewFile'
+      local note = Note:new(note_name)
+      note:set_header() -- Uses note.name by default
+
+      local content = note:get_content()
+      assert.are.equal(1, #content)
+      assert.are.equal('# ' .. note_name, content[1])
+    end)
+
+    it('should create a header with specified name in a new file', function()
+      local note_name = 'SetHeaderNewFileCustom'
+      local header_text = 'My Custom Header for New File'
+      local note = Note:new(note_name)
+      note:set_header(header_text)
+
+      local content = note:get_content()
+      assert.are.equal(1, #content)
+      assert.are.equal('# ' .. header_text, content[1])
+    end)
+
+    it('should update an existing header', function()
+      local note_name = 'UpdateHeaderNote'
+      local new_header_text = 'Updated Shiny Header'
+      helpers.create_test_file(note_name .. '.md', '# Old Header\nLine 2')
+      local note = Note:new(note_name)
+      note:set_header(new_header_text)
+
+      local content = note:get_content()
+      assert.are.equal(2, #content)
+      assert.are.equal('# ' .. new_header_text, content[1])
+      assert.are.equal('Line 2', content[2])
+    end)
+
+    it('should add a header to a file that has content but no header', function()
+      local note_name = 'AddHeaderToExistingContent'
+      local file_content = { 'First line of text', 'Second line' }
+      helpers.create_test_file(note_name .. '.md', table.concat(file_content, '\n'))
+      local note = Note:new(note_name)
+      note:set_header() -- Uses note.name
+
+      local content = note:get_content()
+      assert.are.equal(3, #content)
+      assert.are.equal('# ' .. note_name, content[1])
+      assert.are.equal(file_content[1], content[2])
+      assert.are.equal(file_content[2], content[3])
+    end)
+
+    it('should add a header to an empty file', function()
+      local note_name = 'AddHeaderToEmptyFile'
+      helpers.create_test_file(note_name .. '.md', '')
+      local note = Note:new(note_name)
+      note:set_header()
+
+      local content = note:get_content()
+      assert.are.equal(1, #content)
+      assert.are.equal('# ' .. note_name, content[1])
+    end)
+  end)
+
+  describe('Note:create_with_header()', function()
+    it('should create a new file with a header if it does not exist', function()
+      local note_name = 'CreateWithHeaderTest'
+      local note = Note:new(note_name)
+      assert.is_false(note:exists())
+
+      note:create_with_header()
+
+      assert.is_true(note:exists())
+      local content = note:get_content()
+      assert.are.equal(1, #content)
+      assert.are.equal('# ' .. note_name, content[1])
+    end)
+
+    it('should do nothing if the file already exists', function()
+      local note_name = 'CreateWithHeaderExistsTest'
+      local initial_content = { '# ' .. note_name, 'Existing line' }
+      helpers.create_test_file(note_name .. '.md', table.concat(initial_content, '\n'))
+
+      local note = Note:new(note_name)
+      note:create_with_header()
+
+      local content = note:get_content()
+      assert.deep_equal(initial_content, content, "Content should not change if file exists")
+    end)
+  end)
+end)


### PR DESCRIPTION
- Added methods to Note class for reading, writing, and managing headers:
  - get_content, write_content
  - get_header, set_header
- Refactored Note:create_with_header to use new file op methods.
- Updated M.notes_rename to leverage new Note class methods for file and header manipulation.
- Added comprehensive tests for the new Note class functionality in `tests/note_spec.lua`.

By Jules jules.google.com/task